### PR TITLE
解决自动布局时placeholderImage显示不出来

### DIFF
--- a/ZCycleView/ZCycleView/ZCycleView.swift
+++ b/ZCycleView/ZCycleView/ZCycleView.swift
@@ -249,9 +249,20 @@ public class ZCycleView: UIView {
     }
     
     private func addPlaceholderImgView() {
-        placeholderImgView = UIImageView(frame: bounds)
+        placeholderImgView = UIImageView(frame: CGRect.zero)
         placeholderImgView.image = placeholderImage
         addSubview(placeholderImgView)
+        placeholderImgView.translatesAutoresizingMaskIntoConstraints = false
+        let hCons = NSLayoutConstraint.constraints(withVisualFormat: "H:|[placeholderImgView]|",
+                                                   options: NSLayoutFormatOptions(),
+                                                   metrics: nil,
+                                                   views: ["placeholderImgView": placeholderImgView])
+        let vCons = NSLayoutConstraint.constraints(withVisualFormat: "V:|[placeholderImgView]|",
+                                                   options: NSLayoutFormatOptions(),
+                                                   metrics: nil,
+                                                   views: ["placeholderImgView": placeholderImgView])
+        addConstraints(hCons)
+        addConstraints(vCons)
     }
     
     private func addCollectionView() {


### PR DESCRIPTION
ZCycleView使用SnapKit自动布局, placeholderImage无法正常显示. 
原因:placeholderImgView使用frame方式初始化. 
解决:使用VFL自动布局.